### PR TITLE
[fix] fixing component name bug

### DIFF
--- a/thermodynamics/make_component_table.py
+++ b/thermodynamics/make_component_table.py
@@ -102,7 +102,7 @@ for i in range(cmdArgs["n_temp"]):
     query = {
         "Action": "Data",
         "Wide": "on",
-        "ID": "C7732185" if cmdArgs["comp_name"] == "H2O" else "C124389",
+        "ID": "C7732185" if cmdArgs["comp_name"].upper() == "H2O" else "C124389",
         "Type": "IsoTherm",
         "Digits": "12",
         "PLow": str(cmdArgs["min_press"]),


### PR DESCRIPTION
Before this fix, when you use lower case component names, the script did not build the correct tables for the H2O component. With this fix, it should be of none importance whether you type e.g. "h2o" or "H2O",