### PR TITLE
adding --paint only option for all a) b) and c)

### DIFF
--- a/geometries/README.md
+++ b/geometries/README.md
@@ -133,3 +133,32 @@ __Note__: Though valid, the option `--poromult` will have no effect on spe11-a c
 The file `spe11b_structured_extruded.vtu` should be produced and can be inspected using [paraview](https://www.paraview.org/) or another
 vtk enabled 3D reader.
 
+## Properties painting on meshes
+
+While `extrude_and_rotate.py` mentioned above work on the 2D generated meshes to extrude them _and_
+paint on them porosities and permeabilities, it also can work as a simple properties painting operation
+while using the `--paint` option on 2D meshes for *spe11a* and *spe11b* and on the 3D generated version
+of *spe11c* (as it does not require any extrusion).
+
+```bash
+gmsh -2 spe11b.geo
+meshio convert spe11b.msh spe11b.vtk
+python3 extrude_and_rotate.py --tri --paint --spe b spe11b.vtk
+#optionally some clean up
+rm -iv spe11b.vtk spe11b.msh
+```
+
+It will then generate an `spe11b_structured_painted.vtu`. In the case of *spe11c*
+the script act likewise.
+
+```bash
+python3 make_spe11c_geo.py --mesh-size 250
+python3 make_structured_mesh.py --variant C -nx 300 -ny 10 -nz 100
+meshio convert spe11c_structured.msh spe11c_structured.vtu
+python3 extrude_and_rotate.py --quad --paint --spe c spe11c_structured.vtu
+#optionally some clean up
+rm -iv spe11c_structured.vtu spe11c_structured.msh
+```
+
+__Note__ : The painted permeabilities on *spe11c* are the permeabilites from *spe11b* and 
+not the permeabilities transformed by Eq.(4.4)

--- a/geometries/extrude_and_rotate.py
+++ b/geometries/extrude_and_rotate.py
@@ -4,14 +4,19 @@
 """
 Generate 1-cells extruded versions of quad and triangle meshes while painting porosity
 and permeability on those. These celldata will be tagged respectively PORO and PERM.
-The attribute celldata denotes facies label. Porosity multipliers for *spe11b* can be triggered
-using --poromult option.
+The attribute celldata denotes facies label.
+
+Porosity multipliers for *spe11b* can be triggered using --poromult option.
+Simple painting of 2D meshes for *spe11a* or *spe11b* can be obtain using --paint option.
+Simple painting for (already) 3D meshes for *spe11c* is also accessible through --paint.
+
 """
 
 import vtk
 import numpy as np
 import argparse
 from functools import partial
+
 
 class spe11_preprocessing:
 
@@ -20,7 +25,6 @@ class spe11_preprocessing:
         self.E = 1.e-2  # dispersion -- unused for now
         self.ratio = {}
         self.modlist = []
-
 
         # region values
         self.perm = [4e-11, 5e-10, 1e-9, 2e-9, 4e-9, 1e-8, 1e-18]  # 7th is 0 by specs
@@ -31,8 +35,9 @@ class spe11_preprocessing:
         self.geom_off = 0.019
         self.depth_off = -1.2
         self.xb = [0, 2.8]
+        self.is_aniso = False
 
-        if spe[0] == "b":
+        if spe[0] == "b" or spe[0] == "c":
             self.perm = [1e-16, 1e-13, 2e-13, 5e-13, 1e-12, 2e-12, 1e-18]  # 7th is 0 by specs
             self.poro = [.1, .2, .2, .2, .25, .35, .0000001]  # ditto
             self.multipliers = [0., 5e4, 0., 0., 5e4, 0., 0.]
@@ -40,8 +45,9 @@ class spe11_preprocessing:
             self.geom_off = 1.0
             self.depth_off = -1200
             self.xb = [0, 8400]
+            self.is_aniso = True
 
-    def process(self, fname, callback):
+    def extrude(self, fname, callback):
         extension = fname.split('.')[-1]
         if extension == "vtk":
             r = vtk.vtkUnstructuredGridReader()
@@ -106,32 +112,8 @@ class spe11_preprocessing:
 
         g3.SetCells(vtk.VTK_WEDGE, cells)
 
-        for i in range(g.GetCellData().GetNumberOfArrays()):
-            array = vtk.vtkTypeInt32Array()
-
-            perm_array = vtk.vtkFloatArray()
-            perm_array.SetName("PERM")
-            perm_array.SetNumberOfComponents(3)
-
-            poro_array = vtk.vtkFloatArray()
-            poro_array.SetName("PORO")
-
-            if (g.GetCellData().GetArray(i).GetName() =="CellEntityIds"):
-                array.SetName("attribute")
-                for j in range(g.GetCellData().GetArray(i).GetNumberOfTuples()):
-                    if g.GetCell(j).GetCellType() == vtk.VTK_TRIANGLE:
-                        attribute = g.GetCellData().GetArray(i).GetValue(j)
-                        array.InsertNextValue(attribute)
-                        perm_array.InsertNextTuple3(self.perm[attribute - 1], self.perm[attribute - 1],
-                                                    self.perm[attribute - 1])  # C-numbering
-                        if j not in self.modlist or not poromult:
-                            poro_array.InsertNextValue(self.poro[attribute - 1])  # C-numbering
-                        else:
-                            poro_array.InsertNextValue(self.poro[attribute - 1]*(1 + self.multipliers[attribute-1]*self.ratio[j]))  # C-numbering
-
-                g3.GetCellData().AddArray(array)
-                g3.GetCellData().AddArray(perm_array)
-                g3.GetCellData().AddArray(poro_array)
+        former_tag = "CellEntityIds"
+        self.paint_data(g, g3, poromult, former_tag=former_tag)
 
         return (g, g3)
 
@@ -141,36 +123,38 @@ class spe11_preprocessing:
         for i in range(g.GetNumberOfCells()):
 
             for iface in range(g.GetCell(i).GetNumberOfEdges()):
-                pe0 = [0,0,0]
-                pe1 = [0,0,0]
+                pe0 = [0, 0, 0]
+                pe1 = [0, 0, 0]
                 pts = g.GetCell(i).GetEdge(iface).GetPoints()
                 pts.GetPoint(0, pe0)
                 pts.GetPoint(1, pe1)
 
-                if pe0[0] == pe1[0] and (np.abs(self.xb[0] - pe0[0]) < eps or np.abs(self.xb[1] - pe0[0]) < eps or np.abs(self.xb[0] - pe1[0]) < eps or np.abs(self.xb[1] - pe1[0]) < eps):
-                        area = np.max(np.abs(np.asarray([pe1[1] - pe0[1],
-                                                  pe1[2] - pe0[2]])))
-                        if g.GetCell(i).GetCellType() == vtk.VTK_TRIANGLE:
-                            p0 = [0,0,0]
-                            p1 = [0,0,0]
-                            p2 = [0,0,0]
+                if pe0[0] == pe1[0] and (
+                        np.abs(self.xb[0] - pe0[0]) < eps or np.abs(self.xb[1] - pe0[0]) < eps or np.abs(
+                        self.xb[0] - pe1[0]) < eps or np.abs(self.xb[1] - pe1[0]) < eps):
+                    area = np.max(np.abs(np.asarray([pe1[1] - pe0[1],
+                                                     pe1[2] - pe0[2]])))
+                    if g.GetCell(i).GetCellType() == vtk.VTK_TRIANGLE:
+                        p0 = [0, 0, 0]
+                        p1 = [0, 0, 0]
+                        p2 = [0, 0, 0]
 
-                            g.GetCell(i).GetPoints().GetPoint(0, p0)
-                            g.GetCell(i).GetPoints().GetPoint(1, p1)
-                            g.GetCell(i).GetPoints().GetPoint(2, p2)
-                            vc = vtk.vtkTriangle.TriangleArea(p0, p1, p2)
-                        elif g.GetCell(i).GetCellType() == vtk.VTK_QUAD:
-                            bounds = [0,0,0,0,0,0]
-                            g.GetCell(i).GetBounds(bounds)
-                            lx = (1 if (bounds[0] == bounds[1]) else bounds[1] - bounds[0])
-                            ly = (1 if (bounds[2] == bounds[3]) else bounds[3] - bounds[2])
-                            lz = (1 if (bounds[4] == bounds[5]) else bounds[5] - bounds[4])
-                            vc = lx * ly * lz
+                        g.GetCell(i).GetPoints().GetPoint(0, p0)
+                        g.GetCell(i).GetPoints().GetPoint(1, p1)
+                        g.GetCell(i).GetPoints().GetPoint(2, p2)
+                        vc = vtk.vtkTriangle.TriangleArea(p0, p1, p2)
+                    elif g.GetCell(i).GetCellType() == vtk.VTK_QUAD:
+                        bounds = [0, 0, 0, 0, 0, 0]
+                        g.GetCell(i).GetBounds(bounds)
+                        lx = (1 if (bounds[0] == bounds[1]) else bounds[1] - bounds[0])
+                        ly = (1 if (bounds[2] == bounds[3]) else bounds[3] - bounds[2])
+                        lz = (1 if (bounds[4] == bounds[5]) else bounds[5] - bounds[4])
+                        vc = lx * ly * lz
 
-                        self.modlist.append(i)
-                        self.ratio[i] = area / vc
+                    self.modlist.append(i)
+                    self.ratio[i] = area / vc
 
-# note do also swap y<->z
+    # note do also swap y<->z
     def quad_mesh(self, poromult, g, g3, geom_off, depth_off):
         off = g.GetNumberOfPoints()
         # set points
@@ -200,6 +184,11 @@ class spe11_preprocessing:
         g3.SetCells(vtk.VTK_HEXAHEDRON, cells)
 
         # transfer data
+        self.paint_data(g, g3, poromult)
+
+        return (g, g3)
+
+    def paint_data(self, g, g3, poromult, former_tag="gmsh:physical"):
         for i in range(g.GetCellData().GetNumberOfArrays()):
             array = vtk.vtkTypeInt32Array()
 
@@ -210,24 +199,52 @@ class spe11_preprocessing:
             poro_array = vtk.vtkFloatArray()
             poro_array.SetName("PORO")
 
-            if (g.GetCellData().GetArray(i).GetName() == "gmsh:physical"):
+            if g.GetCellData().GetArray(i).GetName() == former_tag:
                 array.SetName("attribute")
                 for j in range(g.GetCellData().GetArray(i).GetNumberOfTuples()):
-                    if g.GetCell(j).GetCellType() == vtk.VTK_QUAD:
+                    if g.GetCell(j).GetCellType() in [vtk.VTK_QUAD, vtk.VTK_TRIANGLE, vtk.VTK_HEXAHEDRON,
+                                                      vtk.VTK_TETRA]:
                         attribute = g.GetCellData().GetArray(i).GetValue(j)
                         array.InsertNextValue(attribute)
                         perm_array.InsertNextTuple3(self.perm[attribute - 1], self.perm[attribute - 1],
-                                                    self.perm[attribute - 1])  # C-numbering
+                                                    (0.1 if self.is_aniso else 1.) * self.perm[
+                                                        attribute - 1])  # C-numbering
                         if j not in self.modlist or not poromult:
                             poro_array.InsertNextValue(self.poro[attribute - 1])  # C-numbering
                         else:
-                            poro_array.InsertNextValue(self.poro[attribute - 1]*(1 + self.multipliers[attribute-1]*self.ratio[j]))  # C-numbering
+                            poro_array.InsertNextValue(self.poro[attribute - 1] * (
+                                    1 + self.multipliers[attribute - 1] * self.ratio[j]))  # C-numbering
+                    # gmsh generated triangle meshes still have line element, so have to skip them or flag them
+                    elif g.GetCell(j).GetCellType() in [vtk.VTK_LINE]:
+                        array.InsertNextValue(-1)
+                        perm_array.InsertNextTuple3(-1., -1., -1.)
+                        poro_array.InsertNextValue(-1.)
 
                 g3.GetCellData().AddArray(array)
                 g3.GetCellData().AddArray(perm_array)
                 g3.GetCellData().AddArray(poro_array)
 
-        return (g, g3)
+    def paint_only(self, fname, poromult, former_tag):
+        extension = fname.split('.')[-1]
+
+        if extension == "vtk":
+            r = vtk.vtkUnstructuredGridReader()
+            r.SetFileName(fname)
+            r.Update()
+        elif extension == "vtu":
+            r = vtk.vtkXMLUnstructuredGridReader()
+            r.SetFileName(fname)
+            r.Update()
+
+        g = r.GetOutput()
+        self.paint_data(g, g, poromult, former_tag)
+
+        writer = vtk.vtkXMLUnstructuredGridWriter()
+        writer.SetFileName(fname.split('.')[0] + '_painted.vtu')
+        writer.SetInputData(g)
+        writer.Write()
+
+        return g
 
 
 if __name__ == "__main__":
@@ -237,6 +254,7 @@ if __name__ == "__main__":
 
     parser.add_argument("--tri", help="for use if triangle mesh to be extruded", action="store_true")
     parser.add_argument("--quad", help="for use if quad mesh to be extruded", action="store_true")
+    parser.add_argument("--paint", help="paint only", action="store_true")
 
     parser.add_argument("--spe", help="paint data from spe11 a or b", nargs=1, default='a', required=True)
     #
@@ -246,9 +264,11 @@ if __name__ == "__main__":
     preproc = spe11_preprocessing()
     preproc.set_data(args.spe)
 
-    if args.tri:
-        preproc.process(args.fname, partial(preproc.triangle_mesh, args.poromult))
+    if args.paint:
+        preproc.paint_only(args.fname, args.poromult, former_tag="gmsh:physical")
+    elif args.tri:
+        preproc.extrude(args.fname, partial(preproc.triangle_mesh, args.poromult))
     elif args.quad:
-        preproc.process(args.fname, partial(preproc.quad_mesh, args.poromult))
+        preproc.extrude(args.fname, partial(preproc.quad_mesh, args.poromult))
     else:
         raise NotImplementedError


### PR DESCRIPTION
This PR introduces few fixes and improvement to 'extrude_and_rotate.py', as follows :

- [x] Fix the non-anisotropic permeability tensors in *spe11-b*
- [x] Adding a '--paint' option that only paint properties on 2D meshes for *spe11-a* and *spe11-b*.
As for *spe11-c*, the generated mesh is already 3D, '--paint' is the only valid option. 

**Note**: for *spe11-c*, this only paint inherited permeability tensors from *spe11-b* and not the rotated version obtained from Eq. (4.4), as it can be introduced or obtained as a post-processing of the read values

**Note**: in the case of painted 2D meshes, the _gmsh_ generated vtk meshes introduces _VTKLINE_ elements that count as cells. On these cells, the permeability, porosity and attribute (region tag) are set to -1.