### PR TITLE
[thermodynamic][fix] using IIR to get reference enthalpies

### DIFF
--- a/thermodynamics/make_component_table.py
+++ b/thermodynamics/make_component_table.py
@@ -109,7 +109,7 @@ for i in range(cmdArgs["n_temp"]):
         "PHigh": str(cmdArgs["max_press"]),
         "PInc": str(delta_pressure),
         "T": str(temperature),
-        "RefState": "DEF",
+        "RefState": "IIR",
         "TUnit": "C",
         "PUnit": "Pa",
         "DUnit": "kg/m3",

--- a/thermodynamics/make_component_table.py
+++ b/thermodynamics/make_component_table.py
@@ -99,6 +99,9 @@ outFile.write("# temperature [°C],     pressure [Pa],   density [kg/m3],  visco
 # get the data
 for i in range(cmdArgs["n_temp"]):
     temperature = cmdArgs["min_temp"] + i * delta_temperature
+    # Below, the reference state IIR is selected, corresponding to
+    # "setting enthalpy to 200 kJ/kg and entropy to 1.0 kJ/(kg-K) for the saturated liquid at 0 °C".
+    # See https://refprop-docs.readthedocs.io/en/latest/GUI/Menu%20Commands/Options%20Menu/reference.html?highlight=IIR#reference-state
     query = {
         "Action": "Data",
         "Wide": "on",

--- a/thermodynamics/make_solubility_table.py
+++ b/thermodynamics/make_solubility_table.py
@@ -70,7 +70,7 @@ def getCO2Densities(temperatures: ParameterRange, pressures: ParameterRange) -> 
             "PHigh": f"{pressures.max}",
             "PInc": f"{pressures.step}",
             "T": str(T),
-            "RefState": "DEF",
+            "RefState": "IIR",
             "TUnit": "C",
             "PUnit": "Pa",
             "DUnit": "kg/m3",

--- a/thermodynamics/make_solubility_table.py
+++ b/thermodynamics/make_solubility_table.py
@@ -60,6 +60,9 @@ def getCO2Densities(temperatures: ParameterRange, pressures: ParameterRange) -> 
     result = np.ndarray(shape=(temperatures.numSamples, pressures.numSamples))
     for i in withProgress(range(temperatures.numSamples)):
         T = temperatures[i]
+        # Below, the reference state IIR is selected, corresponding to
+        # "setting enthalpy to 200 kJ/kg and entropy to 1.0 kJ/(kg-K) for the saturated liquid at 0 °C".
+        # See https://refprop-docs.readthedocs.io/en/latest/GUI/Menu%20Commands/Options%20Menu/reference.html?highlight=IIR#reference-state
         query = {
             "Action": "Data",
             "Wide": "on",


### PR DESCRIPTION
When using `"RefState": "DEF"` contrary to what one would expect, NIST does not deliver thermodynamic data that has equal reference states for both H2O and CO2. This lead to several seemingly incorrect results in simulations, such as strangely deep temperatures at the injection well. This could be fixed with changing the `RefState` option to "IIR`.
When `"RefState": "IIR!` is used, the tables for both components will have the same reference states:
Reference States, IIR Convention
Enthalpy : H = 200 kJ/kg at 0°C for saturated liquid.
Entropy: S = 1 J/g*K at 0°C for saturated liquid.
