### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 This repository accompanies the 11th Society of Petroleum Engineers Comparative Solution Project, see https://spe.org/csp/.
 
 To access data and scripts interactively, open this repo on the NFDI JupyterHub:
-[![NFDI](https://nfdi-jupyter.de/images/nfdi_badge.svg)](https://hub.nfdi-jupyter.de/r2d/gh/Simulation-Benchmarks/11thSPE-CSP?system=JSC-Cloud&flavor=xl1nfdi&labpath=notebooks%2Fstart.ipynb)
+[![NFDI](https://nfdi-jupyter.de/images/nfdi_badge.svg)](https://hub.nfdi-jupyter.de/v2/gh/Simulation-Benchmarks/11thSPE-CSP/HEAD?system=JSC-Cloud&flavor=xl1nfdi&labpath=notebooks%2Fstart.ipynb)
 
 Navigate to one of the following folders for accessing the corresponding material:
 


### PR DESCRIPTION
Jupyter4NFDI is now using the official Repo2Docker structure, therefore a ref is required in the direct url